### PR TITLE
changed side nav, fixed double scroll bars

### DIFF
--- a/_app/css/chutter.sass
+++ b/_app/css/chutter.sass
@@ -62,6 +62,7 @@ md-dialog
   margin-top: 64px
   transform: translateY(64px)
   -webkit-transform: translateY(64px)
+  -moz-transform: translateY(64px)
 #scrolly-right
   padding: 16px    
   md-content
@@ -110,8 +111,8 @@ table
 
 md-sidenav
   z-index: 19
-  overflow: hidden
-  margin-top: 64px
+.md-sidenav-left
+  overflow: hidden!important
 
 
 post

--- a/_app/css/chutter.sass
+++ b/_app/css/chutter.sass
@@ -111,6 +111,7 @@ table
 md-sidenav
   z-index: 19
   overflow: hidden
+  margin-top: 64px
 
 
 post

--- a/_app/css/chutter.sass
+++ b/_app/css/chutter.sass
@@ -110,6 +110,7 @@ table
 
 md-sidenav
   z-index: 19
+  overflow: hidden
 
 
 post


### PR DESCRIPTION
Fix: main app

Fixed visual bug in sidenav, it had double scroll bars. Added overflow:hidden to remove one. (seen in firefox)
[Bug image](http://i.imgur.com/0KvBR3G.png)

EDIT:
overflow:hidden was responsible for hiding first item from list (science) and had to add margin-top: 64px (height of navbar) to fix it.
