### PR TITLE
implementation of themes with 5 themes supported

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -215,6 +215,7 @@ module.exports = (grunt) ->
         src: [
           'vendor/angular-material/angular-material.css',
           'app/css/chutter.css',
+          'app/css/chutterThemes.css',
           'app/css/menu.css',
           'app/css/comments.css',
           'app/css/post.css',
@@ -239,6 +240,7 @@ module.exports = (grunt) ->
       dist:
         files:
           'app/css/chutter.css' : '_app/css/chutter.sass'
+          'app/css/chutterThemes.css' : '_app/css/chutterThemes.sass'
           'app/css/main.css' : '_app/css/main.sass'
           'app/css/menu.css' : '_app/css/menu.sass'
           'app/css/me.css' : '_app/css/me.sass'

--- a/_app/css/chutter.sass
+++ b/_app/css/chutter.sass
@@ -1,5 +1,7 @@
 @import '../../vendor/sass-material-colors/sass/sass-material-colors'
-//variables/mixins
+//------------------------------
+// Variables & Mixins
+//------------------------------
 @mixin min-and-max-width($width) 
   width: $width
   min-width: $width
@@ -8,7 +10,6 @@
   height: $height
   min-height: $height
   max-height: $height
-
 
 $sidenav-width: 16vw
 $sidenav-padding: 0 1.25vw
@@ -34,12 +35,11 @@ $span-small-size: 0.9em
 $h6-size: 1em
 $h5-size: 1em
 
-$color-link: rgb(3,169,244)
-
+//------------------------------
+// Global / Overrides
+//------------------------------
 a
-  color: $color-link
   text-decoration: none
-
 h1,h2,h3,h4,h5,h6,p,span, a
   text-rendering: optimizeLegibility
 h6
@@ -52,30 +52,21 @@ h5
 .md-mini
   .icon
     font-size: 17px
-
-//global / overrides
-a.md-button#logo
+#logo
   img
-    margin-top: 6%
     max-width: 8vmax
     max-height: 100%
-
+    vertical-align: middle
 body
   overflow: hidden
-body,
-md-sidenav,
-md-content
-  background-color: material-color('grey', '100')
-  &.primary-content
-    background-color: #fff
-//md-content inside dialogs/tabs should be white
+
 md-tabs
   md-tab-item
     max-width: none !important
   md-content
-    background-color: #fff
+    background-color: #fff //todo: set .primary-content as alternative
     &.detailed-list
-      background-color: #f2f2f2
+      background-color: #f2f2f2 //todo: set .primary-content as alternative
 
 md-bottom-sheet
   padding: 0 0 80px 0
@@ -85,8 +76,22 @@ md-bottom-sheet
   @media(max-width: 960px)
     width: 100vw
 
+.button-link
+  // This can be used to create md-button with theme color(md-primary/md-accent) but make it look like link
+  // You also need to add [md-no-ink="true"] attribute to md-button
+  padding: 0
+  margin: 0
+  line-height: inherit
+  min-height: 0
+  min-width: 0
+  vertical-align: middle
+  text-transform: none
+  &:hover
+    background-color: transparent !important
 
-// custom sidenav overrides using vw/vh units
+//------------------------------
+// Custom sidenav overrides using vw/vh units
+//------------------------------
 md-sidenav.md-locked-open
   @include min-and-max-width($sidenav-width)
   height: calc(100vh - 128px)
@@ -98,39 +103,36 @@ md-backdrop.md-sidenav-backdrop
   @media(max-width: 960px) 
     z-index: $sidenav-z-index-sm
 
-
-#dialog-content
-  background-color: #fff
-
-//vote icons
+//------------------------------
+// Vote icons
+//------------------------------
 i,
 .icon
   &.active-up
     color: rgb(3,169,244)
   &.active-down
     color: rgb(244,67,54)
-#create
-  md-content
-    background: #fff
+
 #submit
   md-autocomplete 
     width: 100%
     min-width: 100%
 
-
-
-
 .inline-link
-  color: rgb(3,169,244)
+  // Not sure this is used anymore, can it be removed? Alternative is .button-link on line of 79 this file
+  color: rgb(3,169,244) // Should be getting it from md-primary
   cursor: hand
   margin-right: 4px
 
+//------------------------------
 // toolbar css. this is all the css relating to the toolbars
 // section specific toolbar css will be located in <appname>.sass
+//------------------------------
 md-toolbar.extra-width
   width: calc(100% + 1px)
-//set base font size
+
 .md-toolbar-tools
+  //set base font size
   font-size: 14px
 
 md-toolbar#main-toolbar,
@@ -150,17 +152,10 @@ md-toolbar#me-toolbar
       margin: 0
       min-width: auto
       text-transform: none
-  .toolbar-container
-    &#titles
-      position: relative
-    a,
-    span
-      font-size: 1.1em
+  #titles
+    position: relative
     @include min-and-max-width($sidenav-width)
     padding: $sidenav-padding
-    &.no-padding
-      padding: 0
-
 
   #breadcrumb 
     padding-top: 4px
@@ -182,27 +177,27 @@ md-toolbar#me-toolbar
       -webkit-transform: translateY(-26px) scale(0.6)
       -moz-transform: translateY(-26px) scale(0.6)
 
+md-toolbar#main-toolbar,
+md-toolbar#moderation-toolbar,
+md-toolbar#management-toolbar,
+md-toolbar#me-toolbar,
+md-toolbar#content-toolbar
+  // Transitions of md-toolbars for depth color switching
+  transition: all 1s cubic-bezier(0.35, 0, 0.25, 1)
 
 
-
+//------------------------------
 // main content area
 // this is all the css relating to the center md-content section
-
-// overlay tall toolbar with the main content 
+//------------------------------
 #content
+  // overlay tall toolbar with the main content
   height: calc(100vh - 64px)
   overflow: hidden
   position: relative
   z-index: $content-z-index-lg
   @media(max-width: 960px) 
     z-index: $content-z-index-sm
-  background: #fff
-
-post
-  background: #fff
-
-#posts
-  height: 100%
 
 .ng-cloak
   display: none !important
@@ -217,7 +212,9 @@ post
   -webkit-transform-style: preserve-3d
   -webkit-transform: translate3d(0,0,0)
 
-// edit subscriptions card 
+//------------------------------
+// Edit subscriptions card
+//------------------------------
 .subscription-card
   margin: 10px 0
   .subscription-info
@@ -237,10 +234,10 @@ post
     width: 40px
     i
       font-size: 40px
-    
 
-
-
+//------------------------------
+// Conversation / Messages
+//------------------------------
 #conversation
   width: 95%
   height: 100%
@@ -304,6 +301,8 @@ post
     &:after
       border: none
 
+//------------------------------
 // Fixes
+//------------------------------
 [layout-fill]
   height: inherit // Chrome layout-fill fix @/angular/material/issues/2058

--- a/_app/css/chutterThemes.sass
+++ b/_app/css/chutterThemes.sass
@@ -1,0 +1,84 @@
+@import "chutter"
+//------------------------------
+// Chutter Themes
+//
+// Current supported themes:
+//    - Chutter
+//    - Chutter Dark
+//
+//------------------------------
+
+//------------------------------
+// NORMAL theme overrides
+//
+// - has to be compatible with future color themes
+//------------------------------
+body:not([md-theme="chutterDark"])
+
+  //------------------------------
+  // Content
+  //------------------------------
+  .primary-content
+    // This is used to enforce md-content background or used where md-content isn't possible
+    background-color: #fff
+  .secondary-content
+    // Darker secondary content. Primary use in sidebars
+    background-color: material-color('grey', '100')
+
+  //------------------------------
+  // Text Colors
+  //------------------------------
+  .color-light
+    color: material-color("grey", "600")
+
+//------------------------------
+// DARK theme overrides
+//
+// - base color is "blue-grey"
+//------------------------------
+[md-theme="chutterDark"]
+
+  //------------------------------
+  // MD-Elements
+  //------------------------------
+  md-bottom-sheet
+    md-content
+      background-color: transparent !important
+  .md-button.md-primary
+    // Buttons with md-primary, should have same color md-accent(blue).
+    // Other themes would leave this same as md-primary, but in ChutterDark, md-primary is grey
+    // and we want it to be md-accent(blue)
+    color: material-color("blue", "400") !important
+  md-tab-content
+    md-content
+      background-color: transparent !important
+
+  //------------------------------
+  // Content
+  //------------------------------
+  .primary-content
+    // This is used to enforce md-content background or used where md-content isn't possible
+    background-color: material-color("blue-grey", "800")
+  .secondary-content
+    // Darker secondary content. Primary use in sidebars
+    background-color: material-color("blue-grey", "900")
+
+  //------------------------------
+  // Text Colors
+  //------------------------------
+  .color-light
+    color: material-color("grey", "400")
+
+  //------------------------------
+  // Specific overrides
+  //
+  // - use this as little as possible
+  //------------------------------
+  .md-sidenav-right
+    .special-list
+      md-list-item
+        .content
+          border-color: material-color("blue-grey", "800") !important
+  comment .main,
+  comment-embed .main
+    border-color: material-color("blue-grey", "700") !important

--- a/_app/css/comments.sass
+++ b/_app/css/comments.sass
@@ -31,8 +31,6 @@ comment-embed
   -webkit-transform: scale(1)
   -moz-transform: scale(1)
   transform: scale(1)
-  .main
-    background: #fff
   .collapsed
     display: none
     &.active
@@ -137,8 +135,7 @@ comment-embed
     .header
       height: 48px
       .md-button
-        margin-left: 10px
-        margin-right: 3px
+        margin-left: 5px
     .username,
     .points,
     .time
@@ -161,16 +158,10 @@ comment-embed
   -moz-transition: transform 250ms ease-in-out
   transition: transform 250ms ease-in-out
 
-  background: #767676
-  background-color: #f6f6f6
-  
   -webkit-transform: scale(0,1)
   -moz-transform: scale(0,1)
   transform: scale(0,1)
   
-  .header
-    background: #f6f6f6
-    background-color: #f6f6f6
   &.active
     transform:  scale(1,1)
     -webkit-transform: scale(1,1)
@@ -212,7 +203,6 @@ comment-embed
 #comments > comment
   margin: 10px 16px
   border-radius: 2px
-  background-color: #FFF
   box-shadow: 0px 1px 5px rgba(0, 0, 0, 0.16)
   >.main
     border-top: none

--- a/_app/css/main.sass
+++ b/_app/css/main.sass
@@ -1,3 +1,4 @@
+@import "chutter"
 // Style tabs to mach site toolbar navigation   Add: .tabs-toolbar to md-tabs if you want this style
 md-tabs#submit.tabs-toolbar
   border-radius: 0
@@ -8,3 +9,14 @@ md-tabs#submit.tabs-toolbar
       top: 8px
   md-tabs-content-wrapper
     top: 64px !important //height of toolbar
+.theme-list
+  .theme-chutter
+    color: material-color('blue')
+  .theme-chutter-dark
+    color: material-color('blue-grey')
+  .theme-chutter-teal
+    color: material-color('teal')
+  .theme-chutter-orange
+    color: material-color('orange')
+  .theme-chutter-pink
+    color: material-color('pink')

--- a/_app/css/post.sass
+++ b/_app/css/post.sass
@@ -137,11 +137,6 @@ md-list#posts
       -moz-transform-origin: top right
     .top
       padding-left: 1vmax
-      .title
-        a.title-text
-          color: #767676
-          font-weight: bolder
-
       .attribution
         padding: 0 8px
         color: #bbb
@@ -157,7 +152,7 @@ md-list#posts
           margin-right: 6px
           color: #999
         &.submitted-by-text,
-        &.time-ago,
+        &.time-ago
           margin-right: 4px
       .user-link
         margin-right: 4px

--- a/_app/css/sidebar.sass
+++ b/_app/css/sidebar.sass
@@ -1,7 +1,6 @@
 @import "chutter"
 //Variables
 $color-white: #fff
-$color-light: #F2F2F2
 $color-dark: #3f3f3f
 
 $font-size-60: 0.60vmax
@@ -17,8 +16,6 @@ $font-size-130: 1.3vmax
       overflow: hidden
   h5
     margin-top: 0
-  .light
-    color: material-color("grey", "600")
   .small
     font-size: $font-size-70
     @media(max-width: 960px) // Responsive font
@@ -41,7 +38,6 @@ $font-size-130: 1.3vmax
         margin: 0 -6px 0 6px
         .icon
           line-height: 36px
-          color: material-color("light-blue") // TODO: Should use theme PRIMARY color
           font-size: $font-size-130
           @media(max-width: 960px) // Responsive font
             font-size: $font-size-130 + 1
@@ -70,26 +66,22 @@ $font-size-130: 1.3vmax
           font-size: $font-size-65 + 1
         display: inline-block
         margin: 0 0.25vmax
-        color: material-color("grey", "600")
-        &:hover
-          color: $color-dark
 
   // List styling (news/moderators)
   $list-height: 2.5vmax
   .special-list
     md-list
       padding: 0
-      background: $color-light
     md-list-item
       min-height: 36px
       padding: 0
       .content
         height: $list-height
-        border-right: 1px solid #DDDDDD
-        border-bottom: 1px solid #DDDDDD
+        border-right: 1px solid #DDDDDD // ChutterDark overrides this to set it darker
+        border-bottom: 1px solid #DDDDDD // ChutterDark overrides this to set it darker
       &:first-child
         .content
-          border-top: 1px solid #DDDDDD
+          border-top: 1px solid #DDDDDD // ChutterDark overrides this to set it darker
       .type
         min-height: 36px
         height: $list-height
@@ -101,13 +93,10 @@ $font-size-130: 1.3vmax
         margin: 0
         border-radius: 0
         padding: 0 0.5vmax
+        background-color: transparent
       .title
-        color: material-color("grey", "600")
         overflow: hidden
         float: left
-        font-size: $font-size-75
-        @media(max-width: 960px) // Responsive font
-          font-size: $font-size-75 + 1
         line-height: $list-height
 
   //All [Chutter "front-page"]
@@ -119,11 +108,6 @@ $font-size-130: 1.3vmax
           color: material-color("red")!important
       .help
         margin-top: 16px
-    .about
-      .icon-holder
-        .icon,
-        .icon:hover
-          color: material-color("light-blue") // TODO: Should use theme PRIMARY color
     .news
       .special-list
         .time
@@ -143,8 +127,6 @@ $font-size-130: 1.3vmax
   //Network
   network-sidebar
     .welcome
-      .md-button
-        margin: 0
       .subscribers
         text-align: center
         line-height: 38px

--- a/_app/js/common-directives.coffee
+++ b/_app/js/common-directives.coffee
@@ -204,7 +204,7 @@ app.directive 'comment', ["$compile", ($compile) ->
         when 2,6,12 then $scope.comment.depthColor = 1
         when 3,7,13 then $scope.comment.depthColor = 2
         when 4,8,14 then $scope.comment.depthColor = 3
-      $compile('<comment class="child" color="{{comment.depthColor}}" collapsed="false" layout="column" ng-repeat="child in comment.children" id="c{{child.path}}" parent="comment" comment="child"></comment>') $scope, (cloned, scope) ->
+      $compile('<comment class="child primary-content" color="{{comment.depthColor}}" collapsed="false" layout="column" ng-repeat="child in comment.children" id="c{{child.path}}" parent="comment" comment="child"></comment>') $scope, (cloned, scope) ->
          $element.append(cloned) 
     $scope.comment.elements = {}
     $scope.comment.element = $element[0]

--- a/_app/js/main/controllers/theme-controllers.coffee
+++ b/_app/js/main/controllers/theme-controllers.coffee
@@ -1,0 +1,12 @@
+app = angular.module('MainApp')
+
+app.controller 'themeCtrl', ['$scope', ($scope) ->
+
+  # Set default theme
+  $scope.theme = "chutter"
+
+  # Change $scope.theme to desired theme name
+  $scope.switchTheme = (themeName) ->
+    $scope.theme = themeName
+
+]

--- a/_app/js/main/main.coffee
+++ b/_app/js/main/main.coffee
@@ -13,10 +13,77 @@ $(document).ready () ->
 
 
 app.config ["$httpProvider", "$mdThemingProvider", ($httpProvider, $mdThemingProvider) ->
-  $mdThemingProvider.theme('default').primaryPalette 'light-blue'
-  $mdThemingProvider.theme('moderator').primaryPalette 'indigo'
 
-  # $httpProvider.interceptors.push ["$q", '$injector','$rootScope', ($q, $injector, $rootScope) ->
+  # Default Chutter
+  chutterMap = $mdThemingProvider.extendPalette('blue', {
+  })
+  # Chutter Dark
+  chutterDarkMap = $mdThemingProvider.extendPalette('blue-grey', {
+  })
+  # Chutter Teal
+  chutterTealMap = $mdThemingProvider.extendPalette('teal', {
+  })
+  # Chutter Orange
+  chutterOrangeMap = $mdThemingProvider.extendPalette('orange', {
+    'contrastDefaultColor': 'light'
+  })
+  # Chutter Pink
+  chutterPinkMap = $mdThemingProvider.extendPalette('pink', {
+  })
+
+  $mdThemingProvider.definePalette('chutter', chutterMap)
+  $mdThemingProvider.definePalette('chutterDark', chutterDarkMap)
+  $mdThemingProvider.definePalette('chutterTeal', chutterTealMap)
+  $mdThemingProvider.definePalette('chutterOrange', chutterOrangeMap)
+  $mdThemingProvider.definePalette('chutterPink', chutterPinkMap)
+
+  # Default Chutter
+  $mdThemingProvider.theme('chutter')
+    .primaryPalette 'chutter', {
+      'hue-1': '700'
+      'hue-2': '800'
+      'hue-3': '900'
+    }
+    .accentPalette 'pink'
+  # Chutter Dark
+  $mdThemingProvider.theme('chutterDark')
+    .primaryPalette 'chutterDark', {
+      'hue-1': '600'
+      'hue-2': '700'
+      'hue-3': '800'
+    }
+    .backgroundPalette 'blue-grey'
+    .accentPalette 'blue'
+    .dark()
+  # Chutter Teal
+  $mdThemingProvider.theme('chutterTeal')
+  .primaryPalette 'chutterTeal', {
+    'hue-1': '600'
+    'hue-2': '700'
+    'hue-3': '800'
+  }
+  .accentPalette 'deep-orange'
+  # Chutter Orange
+  $mdThemingProvider.theme('chutterOrange')
+  .primaryPalette 'chutterOrange', {
+    'hue-1': '600'
+    'hue-2': '700'
+    'hue-3': '800'
+  }
+  .accentPalette 'deep-orange'
+  # Chutter Pink
+  $mdThemingProvider.theme('chutterPink')
+  .primaryPalette 'chutterPink', {
+    'hue-1': '600'
+    'hue-2': '700'
+    'hue-3': '800'
+  }
+  .accentPalette 'indigo'
+
+  $mdThemingProvider.setDefaultTheme('chutter')
+  $mdThemingProvider.alwaysWatchTheme(true)
+
+# $httpProvider.interceptors.push ["$q", '$injector','$rootScope', ($q, $injector, $rootScope) ->
   #   {
   #     responseError: (rejection) ->
   #       if rejection.status == 401

--- a/_app/js/main/providers/main-states.coffee
+++ b/_app/js/main/providers/main-states.coffee
@@ -31,6 +31,8 @@ app.config(['$stateProvider', '$urlRouterProvider', ($stateProvider, $urlRouterP
         Page.scope = "all"
         Page.title = "All"
         Page.url_prefix = "/"
+        Page.mainToolbar = ""
+        Page.secondaryToolbar = "md-hue-1"
       ]
     all_hot =
       name: "home.all.hot"
@@ -83,6 +85,8 @@ app.config(['$stateProvider', '$urlRouterProvider', ($stateProvider, $urlRouterP
       ]
       onEnter: ["Page", (Page) ->
         Page.scope = "network"
+        Page.mainToolbar = "md-hue-1"
+        Page.secondaryToolbar = "md-hue-2"
       ]
       controller: "networkCtrl"
     
@@ -130,6 +134,8 @@ app.config(['$stateProvider', '$urlRouterProvider', ($stateProvider, $urlRouterP
         ]
       onEnter: ["Page", (Page) ->
         Page.scope = "community"
+        Page.mainToolbar = "md-hue-2"
+        Page.secondaryToolbar = "md-hue-3"
       ]
       controller: "communityCtrl"
       views:
@@ -215,6 +221,8 @@ app.config(['$stateProvider', '$urlRouterProvider', ($stateProvider, $urlRouterP
       url: "/:id"
       onEnter: ["Page", (Page) ->
         Page.scope = "comments"
+        Page.mainToolbar = "md-hue-2"
+        Page.secondaryToolbar = "md-hue-3"
       ]
       resolve: 
         Post: ["PostResource", "$stateParams", (PostResource, $stateParams) ->

--- a/_app/partials/main/comments.haml
+++ b/_app/partials/main/comments.haml
@@ -1,6 +1,6 @@
 %div{style: "z-index: 120;"}
-  %post.post{post: "page.post",  layout: "row"}
-%md-toolbar#comment-toolbar.md-hue-2{md-scroll-shrink: true, layout-align: "center", layout: "column"}
+  %post.post.primary-content{post: "page.post",  layout: "row"}
+%md-toolbar#comment-toolbar{md-scroll-shrink: true, layout-align: "center", layout: "column", ng-class: "page.secondaryToolbar"}
   .md-toolbar-tools{layout: "row", layout-fill: "true"}
     %md-tabs.md-hue-2{md-no-pagination: "true", flex: "true"}
       %md-tab
@@ -18,9 +18,9 @@
     %span.comments{hide-sm: "true", ng-bind: "page.post.comments_count + ' comments'"}
     %md-button.md-icon-button{hide-sm: "true"}
       %i.icon.ion-ios-trash
-%md-content#comments
+%md-content#comments.secondary-content
   #comment-wrapper{infinite-scroll: "fetchMoreComments()", infinite-scroll-container: "'#comments'", infinite-scroll-distance: "1"}
-    %comment{parent: "", layout: "column", ng-repeat: "child in page.comments",id: "c{{child.path}}", comment: "child"}
+    %comment.primary-content{parent: "", layout: "column", ng-repeat: "child in page.comments",id: "c{{child.path}}", comment: "child"}
 
 %md-button.md-fab.post-comment{ng-if: "user && user.id", aria-label: "Comment", ng-click: "reply()"}
   %i.icon.ion-ios-chatbubble

--- a/_app/partials/main/communityPosts.haml
+++ b/_app/partials/main/communityPosts.haml
@@ -1,6 +1,6 @@
-%md-toolbar.md-primary.md-hue-3{md-scroll-shrink: "true", layout-align: "center", layout: "column"}
+%md-toolbar.md-primary{md-scroll-shrink: "true", layout-align: "center", layout: "column", ng-class: "page.secondaryToolbar"}
   .md-toolbar-tools
-    %md-tabs.md-primary.md-hue-3{md-no-pagination: "true", flex: "true"}
+    %md-tabs.md-primary{md-no-pagination: "true", flex: "true", ng-class: "page.secondaryToolbar"}
       %md-tab{ui-sref: "home.community.hot"}
         %md-tab-label
           %h3

--- a/_app/partials/main/index.haml
+++ b/_app/partials/main/index.haml
@@ -1,5 +1,5 @@
 !!! 5
-%html{lang: "en", ng-app: "MainApp", xmlns:ng: "http://angularjs.org"}
+%html{lang: "en", ng-app: "MainApp", xmlns:ng: "http://angularjs.org", ng-controller: "themeCtrl"}
   %head
     %base{href: "/"}
 
@@ -17,10 +17,10 @@
 
     %title Chutter &mdash;
 
-  %body{layout: "row", layout-fill: true}
+  %body{layout: "row", layout-fill: true, md-theme: "{{theme}}"}
     %ui-view{layout: "column", layout-fill: true}
-        %div{layout: "column", layout-fill: "true", layout-align: "center center"}
-            %md-progress-circular{md-mode: "indeterminate"}
+      %div{layout: "column", layout-fill: "true", layout-align: "center center"}
+        %md-progress-circular{md-mode: "indeterminate"}
 
     %script{src: "/js/compiled/application.min.js"}
     %script{src: "/js/compiled/main.min.js"}

--- a/_app/partials/main/layout.haml
+++ b/_app/partials/main/layout.haml
@@ -1,68 +1,87 @@
 %md-content{layout: "row", flex: true, layout-align: "end end"}
-  %md-toolbar.md-whiteframe-z1.md-tall#main-toolbar
-    .md-toolbar-tools{ng-hide: "user && user.id", layout: "row", flex: "100"}
+  %md-toolbar.md-whiteframe-z1.md-tall#main-toolbar{ng-class: "page.mainToolbar"}
+    .md-toolbar-tools{ng-hide: "user && user.id", layout: "row", flex: "100", layout-align: "space-between center"}
       .toolbar-container.no-padding{layout: "row", layout-align: "center center"}
-          .nav-list-item{hide-sm: "true"}
-            %md-button#logo{aria-label: "logo", style: "background-color: transparent;", ui-sref: "home.all.hot", layout: "column", layout-align: "center center"}
-              %img{ng-src: "/img/logo.png"} 
-          %md-button.md-icon-button{aria-label: "toggle left", hide-gt-sm: "true", ng-click: "toggleLeft()"}
-            %i.icon.ion-navicon  
-      %span{hide-sm: "true", flex: true}
+        .nav-list-item{hide-sm: "true"}
+          %md-button#logo{style: "background-color: transparent;", ui-sref: "home.all.hot", layout: "column", layout-align: "center center"}
+            %img{ng-src: "/img/logo.png"}
+        %md-button.md-icon-button{aria-label: "toggle left", hide-gt-sm: "true", ng-click: "toggleLeft()"}
+          %i.icon.ion-navicon
       %div{hide-gt-sm: "true", flex: "true", layout: "row", layout-align: "center center"}
         %md-button.md-icon-button{aria-label: "home"}
           %md-icon{md-svg-src: "/img/character.svg", style: "height: 40px; width: 40px; fill: #000;"}
       .toolbar-container{layout: "row", layout-align: "end end"}
         %md-button{aria-label: "sign in", ng-click: "signIn()"}
           Sign In
-    
-    .md-toolbar-tools{ng-show: "user && user.id", layout: "row", flex: "100"}
+
+    .md-toolbar-tools{ng-show: "user && user.id", layout: "row", flex: "100", layout-align: "space-between center"}
       .toolbar-container.no-padding{layout: "row", layout-align: "center center"}
-          .nav-list-item
-            %md-button#logo{aria-label: "logo", style: "background-color: transparent;", ui-sref: "home.all.hot", layout: "column", layout-align: "center center"}
-              %img{ng-src: "img/logo.png", hide-sm: "true"}
-      %span{flex: true}
-      .toolbar-container{hide-sm: true, hide-md: true, layout: "row", layout-align: "end end"}
-        %md-button{aria-label: "moderation", ng-if: "user.moderator", href: "/moderation", target: "_self", ng-bind: "'moderation'"}
-        %md-button{aria-label: "management", ng-if: "user.manager", href: "/management", target: "_self", ng-bind: "'management'"}
-        %md-button{aria-label: "notifications", href: "/me/notifications", ng-bind: "user.username", target: "_self"}
-        %md-button{aria-label: "conversations", href: "/me/conversations", target: "_self", hide-sm: true}
+        .nav-list-item
+          %md-button#logo{style: "background-color: transparent;", ui-sref: "home.all.hot", layout: "column", layout-align: "center center"}
+            %img{ng-src: "img/logo.png", hide-sm: "true"}
+      .toolbar-container{hide-sm: true, hide-md: true, layout: "row", layout-align: "end center"}
+        %md-button{aria-label: "moderation", ng-if: "user.moderator", href: "/moderation", target: "_self"}
+          Moderation
+        %md-button{aria-label: "management", ng-if: "user.manager", href: "/management", target: "_self"}
+          Management
+        %md-menu
+          %md-button.md-icon-button{aria-label: "change theme", ng-click: "$mdOpenMenu($event)"}
+            .icon.ion-android-color-palette
+          %md-menu-content.theme-list
+            %md-button{aria-label: "change theme", ng-click: "switchTheme('chutter')"}
+              .theme-chutter
+                Chutter
+            %md-button{aria-label: "change theme", ng-click: "switchTheme('chutterDark')"}
+              .theme-chutter-dark
+                Chutter Dark
+            %md-button{aria-label: "change theme", ng-click: "switchTheme('chutterTeal')"}
+              .theme-chutter-teal
+                Chutter Teal
+            %md-button{aria-label: "change theme", ng-click: "switchTheme('chutterOrange')"}
+              .theme-chutter-orange
+                Chutter Orange
+            %md-button{aria-label: "change theme", ng-click: "switchTheme('chutterPink')"}
+              .theme-chutter-pink
+                Chutter Pink
+
+        %md-button{aria-label: "notifications", href: "/me/notifications", target: "_self"}
+          {{::user.username}}
+        %md-button.md-icon-button{aria-label: "messages", href: "/me/conversations", target: "_self", hide-sm: true}
           %i.icon.ion-android-mail
           %md-tooltip
             Messages
-        %md-button{aria-label: "sign out", ng-click: "logout()", hide-sm: true}
+        %md-button.md-icon-button{aria-label: "logout", ng-click: "logout()", hide-sm: true}
           %i.icon.ion-log-out
           %md-tooltip
             Log out
-    .md-toolbar-tools.md-toolbar-tools-bottom{layout: "row"}
+    .md-toolbar-tools.md-toolbar-tools-bottom{layout: "row", layout-align: "space-between"}
       .toolbar-container.no-padding{layout: "row", layout-align: "center center"}
         .nav-list-item
           %md-button{ui-sref: "home.all.hot"}
             %p All
-          %md-button.secondary-action.md-icon-button{aria-controls: "all", aria-label: "edit network", ng-click: "editNetworks()"}
-            %span.icon.ion-ios-settings 
-      %span{flex: true}
-      .toolbar-container#titles{layout: "row", layout-align: "center center"}
+          %md-button.secondary-action.md-icon-button
+            %span.icon.ion-ios-settings{aria-controls: "all", aria-label: "edit network", ng-click: "editNetworks()"}
+      .toolbar-container#titles{layout: "row", layout-align: "space-between center"}
         %a#primary-title{ui-sref: "home.network.hot({network: page.title.slug})", ng-bind: "page.title.text", ng-class: "{'active': page.secondary_title}"}
         %a#secondary-title{ng-if: "page.secondary_title", ui-sref: "home.community.hot({community: page.secondary_title.slug})", ng-bind: "page.secondary_title.text"}
-        %span{flex: true}
         %md-button.md-fab.md-mini{md-direction: "down", ng-if: "page.scope == 'community'", ui-sref: "home.community.submit({community: page.community.slug})"}
           %i.icon.ion-android-share
 
-            
+
   %md-sidenav.md-sidenav-left{md-component-id: "left", md-is-locked-open: "$mdMedia('gt-md')"}
-    %md-content.nav-list{flex: true, role: "navigation", layout-fill: true, layout: "column"}
+    %md-content.nav-list.secondary-content{flex: true, role: "navigation", layout-fill: true, layout: "column"}
       .nav-list-wrapper{ng-repeat: "network in page.networks | orderBy:'name'"}
         .nav-list-item{ui-sref-active: "opened"}
           %md-button{aria-label: "network", ui-sref: "home.network.hot({network: network.slug})", layout: "row", layout-align: "center start"}
             %p{ng-bind: "::network.name"}
           %md-button.secondary-action.md-icon-button{aria-controls: "{{::network.name}} edit", aria-label: "edit communities", layout: "row", layout-align: "center center", ng-click: "editNetworkCommunities(network)"}
-            %span.ion-ios-settings 
+            %span.ion-ios-settings
         .subnav-list-item
-          %md-button{aria-label: "community", ng-repeat: "community in network.communities", ng-bind: "community.name", ui-sref: "home.community.hot({community: community.slug})"}      
+          %md-button{aria-label: "community", ng-repeat: "community in network.communities", ng-bind: "community.name", ui-sref: "home.community.hot({community: community.slug})"}
   #content.md-whiteframe-z1{flex: true, layout: "row"}
     %ui-view{layout: "column", layout-fill: "true"}
 
   %md-sidenav.md-sidenav-right{md-component-id: "right", md-is-locked-open: "$mdMedia('gt-md')"}
-    %md-content{ui-view: "right-rail", layout: "column", layout-fill: "layout-fill"}
+    %md-content.secondary-content{ui-view: "right-rail", layout: "column", layout-fill: "layout-fill"}
     %span{flex:true}
-    %footer-sidebar
+    %footer-sidebar.secondary-content

--- a/_app/partials/main/networkPosts.haml
+++ b/_app/partials/main/networkPosts.haml
@@ -1,6 +1,6 @@
-%md-toolbar.md-primary.md-hue-1{md-scroll-shrink: "true", layout-align: "center", layout: "column"}
+%md-toolbar.md-primary{md-scroll-shrink: "true", layout-align: "center", layout: "column", ng-class: "page.secondaryToolbar"}
   .md-toolbar-tools
-    %md-tabs.md-primary.md-hue-1{md-no-pagination: "true", flex: "true"}
+    %md-tabs.md-primary{md-no-pagination: "true", flex: "true", ng-class: "page.secondaryToolbar"}
       %md-tab{ui-sref: "home.network.hot"}
         %md-tab-label
           %h3

--- a/_app/partials/main/posts.haml
+++ b/_app/partials/main/posts.haml
@@ -1,6 +1,6 @@
-%md-toolbar.md-primary.md-hue-2{md-scroll-shrink: "true", layout-align: "center", layout: "column"}
+%md-toolbar.md-primary{md-scroll-shrink: "true", layout-align: "center", layout: "column", ng-class: "page.secondaryToolbar"}
   .md-toolbar-tools{ng-switch: "page.scope", layout: "row", layout-fill: "true"}
-    %md-tabs.md-primary.md-hue-2{md-no-pagination: "true", flex: "true"}
+    %md-tabs.md-primary{md-no-pagination: "true", flex: "true", ng-class: "page.secondaryToolbar"}
       %md-tab{ui-sref: "home.all.hot"}
         %md-tab-label
           %h3
@@ -15,4 +15,4 @@
           %h3
             top
 
-%md-content#posts.primary-content{infinite-scroll: "myPagingFunction()", infinite-scroll-distance: "3", ui-view: "posts"}
+%md-content{infinite-scroll: "myPagingFunction()", infinite-scroll-distance: "3", ui-view: "posts"}

--- a/_app/partials/main/sidebar/all-sidebar.haml
+++ b/_app/partials/main/sidebar/all-sidebar.haml
@@ -7,7 +7,7 @@
         %h5.md-title
           Subscription Goal
 
-      .light.sub-header
+      .color-light.sub-header
         Help us make this site available for the world.
     %md-progress-linear.md-warn{md-mode: "determinate", value: "33"}
     %md-button.md-primary.help{aria-label: "Help Chutter", ng-click: "openSubscriptionDialog()"}
@@ -19,18 +19,18 @@
           %img{src: "/img/small-logo.png", style: "max-height: 100%;"}
         %h5.md-title
           Chutter.co
-      .light.sub-header
+      .color-light.sub-header
         Is a new place to share best stuff on the web.
     %md-button.md-primary
       Learn more
   .news
     .header{layout: "row", layout-wrap: "layout-wrap", flex: 100}
       .title{layout: "row", flex: 100, layout-align: "start center"}
-        %md-button.md-icon-button
+        %md-button.md-icon-button.md-primary
           .icon.ion-ios-pulse-strong
         %h5.md-title
           News
-      .light.sub-header
+      .color-light.sub-header
         Things happening with Chutter.
     %md-list.special-list
       %md-list-item{layout: "row"}
@@ -39,9 +39,9 @@
           %md-tooltip{md-direction: "left"}
             Update
         %md-button.content{layout: "row", flex: true}
-          .title{flex: 75}
+          .title.md-body-1.color-light{flex: 75}
             Version 2.0
-          %span.time.light{layout-align: "end"}
+          %span.time.color-light{layout-align: "end"}
             10. Jun
       %md-list-item{layout: "row"}
         .type.important{flex: 15, layout: "column", layout-align: "center center"}
@@ -49,9 +49,9 @@
           %md-tooltip{md-direction: "left"}
             Important
         %md-button.content{layout: "row", flex: true}
-          .title{flex: 75}
+          .title.md-body-1.color-light{flex: 75}
             Security breach
-          %span.time.light{layout-align: "end"}
+          %span.time.color-light{layout-align: "end"}
             10. Jun
       %md-list-item{layout: "row"}
         .type.community{flex: 15, layout: "column", layout-align: "center center"}
@@ -59,7 +59,7 @@
           %md-tooltip{md-direction: "left"}
             Community
         %md-button.content{layout: "row", flex: true}
-          .title{flex: 75}
+          .title.md-body-1.color-light{flex: 75}
             AMA Chutter Dev
-          %span.time.light{layout-align: "end"}
+          %span.time.color-light{layout-align: "end"}
             10. Jun

--- a/_app/partials/main/sidebar/comments-sidebar.haml
+++ b/_app/partials/main/sidebar/comments-sidebar.haml
@@ -2,29 +2,29 @@
   .welcome{layout: "row", layout-wrap: "layout-wrap", layout-align: "space-between"}
     .header{layout: "row", layout-wrap: "layout-wrap", flex: 100}
       .title{layout: "row", flex: 100, layout-align: "start center"}
-        %md-button.md-icon-button{aria-label: "Subscribe", ng-click: "page.community.toggle(page.community)"}
+        %md-button.md-icon-button.md-primary{aria-label: "Subscribe", ng-click: "page.community.toggle(page.community)"}
           .icon{ng-class: "page.community.subscribed ? 'ion-minus-round': 'ion-plus-round'"}
           %md-tooltip{md-direction: "left"}
             %span{ng-bind: "page.community.subscribed ? 'Unsubscribe': 'Subscribe'"}
         %h5.md-title{ng-bind: "'/c/'+page.community.slug"}
-      .light.sub-header{ng-bind: "::page.community.description"}
-    .light.small
+      .color-light.sub-header{ng-bind: "::page.community.description"}
+    .color-light.small
       1425 Subscribers
   .rules
     .header{layout: "row", layout-wrap: "layout-wrap", flex: 100}
       .title{layout: "row", flex: 100, layout-align: "start center"}
-        %md-button.md-icon-button{aria-label: "More rules"}
+        %md-button.md-icon-button.md-primary{aria-label: "More rules"}
           .icon.ion-chatbox-working
           %md-tooltip{md-direction: "left"}
             %span
               Rules
         %h5.md-title
           Commenting Rules
-      .light.sub-header
+      .color-light.sub-header
         You could get punished if you wont read them!
     %md-list
       %md-list-item{ng-repeat: "rule in page.community.rules"}
         .header{layout: "row", layout-wrap: "layout-wrap"}
           .title{layout: "row", flex: 100, layout-align: "space-between center"}
             %h5.md-title{ng-bind: "::rule.category"}
-          .light.sub-header{ng-bind: "::rule.detailed_explanation"}
+          .color-light.sub-header{ng-bind: "::rule.detailed_explanation"}

--- a/_app/partials/main/sidebar/community-sidebar.haml
+++ b/_app/partials/main/sidebar/community-sidebar.haml
@@ -3,13 +3,13 @@
     .welcome{layout: "row", layout-wrap: "layout-wrap", layout-align: "space-between"}
       .header{layout: "row", layout-wrap: "layout-wrap", flex: 100}
         .title{layout: "row", flex: 100, layout-align: "start center"}
-          %md-button.md-icon-button{aria-label: "Subscribe", ng-click: "page.community.toggle(page.community)"}
+          %md-button.md-icon-button.md-primary{aria-label: "Subscribe", ng-click: "page.community.toggle(page.community)"}
             .icon{ng-class: "page.community.subscribed ? 'ion-minus-round': 'ion-plus-round'"}
             %md-tooltip{md-direction: "left"}
               %span{ng-bind: "page.community.subscribed ? 'Unsubscribe': 'Subscribe'"}
           %h5.md-title{ng-bind: "'/c/'+page.community.slug"}
-        .light.sub-header{ng-bind: "::page.community.description"}
-      .light.small
+        .color-light.sub-header{ng-bind: "::page.community.description"}
+      .color-light.small
         1425 Subscribers
     .rules
       .header{layout: "row", layout-wrap: "layout-wrap", flex: 100}
@@ -28,18 +28,18 @@
           .header{layout: "row", layout-wrap: "layout-wrap"}
             .title{layout: "row", flex: 100, layout-align: "space-between center"}
               %h5{ng-bind: "::rule.category"}
-            .light.sub-header{ng-bind: "::rule.detailed_explanation"}
+            .color-light.sub-header{ng-bind: "::rule.detailed_explanation"}
     .moderators
       .header{layout: "row", layout-wrap: "layout-wrap", flex: 100}
         .title{layout: "row", flex: 100, layout-align: "start center"}
-          %md-button.md-icon-button{aria-label: "Contact Moderators"}
+          %md-button.md-icon-button.md-primary{aria-label: "Contact Moderators"}
             .icon.ion-android-mail
             %md-tooltip{md-direction: "left"}
               %span
                 Message Moderators
           %h5.md-title
             Moderators
-        .light.sub-header
+        .color-light.sub-header
           The force is strong with this ones.
       %md-list.special-list
         %md-list-item{layout: "row", ng-repeat: "moderator in moderators"}

--- a/_app/partials/main/sidebar/footer-sidebar.haml
+++ b/_app/partials/main/sidebar/footer-sidebar.haml
@@ -1,15 +1,15 @@
 %md-divider
 #footer{layout-align: "center center", layout: "row"}
   .links{flex: 80}
-    %a
+    %a.color-light
       Help
-    %a
+    %a.color-light
       Report bug
-    %a
+    %a.color-light
       Faq
-    %a
+    %a.color-light
       Values
-    %a
+    %a.color-light
       Rules
-    %a
+    %a.color-light
       Contact

--- a/_app/partials/main/sidebar/network-sidebar.haml
+++ b/_app/partials/main/sidebar/network-sidebar.haml
@@ -2,30 +2,30 @@
   .welcome{layout: "row", layout-wrap: "layout-wrap", layout-align: "space-between"}
     .header{flex: 100, layout: "row", layout-wrap: "layout-wrap", flex: 100}
       .title{layout: "row", flex: 100, layout-align: "start center"}
-        %md-button.md-icon-button{aria-label: "Subscribe", ng-click: "page.network.toggle(page.network)"}
+        %md-button.md-icon-button.md-primary{aria-label: "Subscribe", ng-click: "page.network.toggle(page.network)"}
           .icon{ng-class: "page.network.subscribed ? 'ion-minus-round': 'ion-plus-round'"}
           %md-tooltip{md-direction: "left"}
             %span{ng-bind: "page.network.subscribed ? 'Unsubscribe': 'Subscribe'"}
         %h5.md-title
           Welcome
-      .light.sub-header
+      .color-light.sub-header
         Some description on how to use this network and why is it even here in first place.
-    %md-button{flex: 100}
-      .light.small
+    %md-button{flex: "true"}
+      .color-light.small
         20 Communities
-    .light.small.subscribers{flex: 100}
+    .color-light.small.subscribers{flex: 100}
       1425 Subscribers
   .trending-communities
     .header{layout: "row", layout-wrap: "layout-wrap", flex: 100}
       .title{layout: "row", flex: 100, layout-align: "start center"}
-        %md-button.md-icon-button
+        %md-button.md-icon-button.md-primary
           .icon.ion-stats-bars
           %md-tooltip{md-direction: "left"}
             %span
               More
         %h5.md-title
           Trending Communities
-      .light.sub-header
+      .color-light.sub-header
         Communities that shine the most
     %md-list{layout: "row", layout-wrap: "layout-wrap", layout-align: "space-between"}
       %md-list-item{flex: 50}

--- a/_app/partials/main/sidebar/submission-sidebar.haml
+++ b/_app/partials/main/sidebar/submission-sidebar.haml
@@ -2,18 +2,18 @@
   .rules
     .header{layout: "row", layout-wrap: "layout-wrap", flex: 100}
       .title{layout: "row", flex: 100, layout-align: "start center"}
-        %md-button.md-icon-button{aria-label: "More rules"}
+        %md-button.md-icon-button.md-primary{aria-label: "More rules"}
           .icon.ion-clipboard
           %md-tooltip{md-direction: "left"}
             %span
               Rules
         %h5.md-title
           Submission Rules
-      .light.sub-header
+      .color-light.sub-header
         You could get punished if you wont read them!
     %md-list
       %md-list-item{ng-repeat: "rule in page.community.rules"}
         .header{layout: "row", layout-wrap: "layout-wrap"}
           .title{layout: "row", flex: 100, layout-align: "start center"}
             %h5{ng-bind: "::rule.category"}
-          .light.sub-header{ng-bind: "::rule.detailed_explanation"}
+          .color-light.sub-header{ng-bind: "::rule.detailed_explanation"}

--- a/_app/partials/shared/comments/comment.haml
+++ b/_app/partials/shared/comments/comment.haml
@@ -1,16 +1,16 @@
 .border{ng-click: "toggle()"}
   .line
 .collapsed{layout-fill: true, layout: "column"}
-  .header{layout: "row"}
+  .header.secondary-content{layout: "row"}
     %md-button.md-icon-button{aria-label: "toggle comment", ng-click: "toggle()"}
       .icon.ion-ios-plus-outline
     %span
-      %a.username{ng-bind: "comment.username", ui-sref: "user.overview({username: comment.username})"}
+      %md-button.md-primary.button-link.username{md-no-ink: true, ng-bind: "comment.username", ui-sref: "user.overview({username: comment.username})"}
       %span.points{ng-bind: "comment.points + ' points'"}
     %span{flex: true}
     %span.time{layout-align: "end"} 42 minutes ago
 
-.main{layout: "row"} 
+.main{layout: "row"}
   .vote{layout: "column", layout-fill: true}
     %md-button.md-icon-button{flex: "30", aria-label: "Upvote",  ng-click: "comment.updateVote(1)"}
       .icon.ion-chevron-up{ng-class: "{'active-up' : (comment.vote == 1)}"}
@@ -22,7 +22,7 @@
   .content{layout: "column", layout-fill: true}
     .header{layout: "row"}
       .wrap
-        %a.username{ng-bind: "comment.username", ui-sref: "user.overview({username: comment.username})"}
+        %md-button.md-primary.button-link.username{md-no-ink: true, ng-bind: "comment.username", ui-sref: "user.overview({username: comment.username})"}
         %span.points{ng-bind: "comment.points + ' points'"}
       %span{flex: true}
       %span.time{layout-align: "end", am-time-ago: "comment.created_at"}

--- a/_app/partials/shared/post.haml
+++ b/_app/partials/shared/post.haml
@@ -17,11 +17,11 @@
     .top{ng-switch: "post.media.length"}
       %div{ng-switch-when: 0}
         .title
-          %a.title-text{ng-bind: "::post.title", ui-sref: "home.community.comments({id: post.slug, community: post.community_slug})"}
+          %a.color-light.md-title{ng-bind: "::post.title", ui-sref: "home.community.comments({id: post.slug, community: post.community_slug})"}
 
       %div{ng-switch-default: true}
         .title
-          %a.title-text{ng-bind: "::post.title", href: "{{::post.media[0].link}}"}
+          %a.color-light.md-title{ng-bind: "::post.title", href: "{{::post.media[0].link}}"}
           %span.attribution{ng-bind: "'('+post.media[0].attribution+')'"}
     .tagline
       %span.votes{ng-bind: "(post.points || 0) + ' points'"} 

--- a/_app/partials/shared/postListItem.haml
+++ b/_app/partials/shared/postListItem.haml
@@ -1,2 +1,2 @@
 #post-list-wrapper{infinite-scroll: "fetchMorePosts()", infinite-scroll-container: "'#posts'", infinite-scroll-distance: "2"}
-  %post.post{ng-repeat: "post in page.posts",  post: "post", post-index: "$index", layout: "row", layout-sm: "column", flex: true, id: "post-{{post.id}}"} 
+  %post.post.primary-content{ng-repeat: "post in page.posts",  post: "post", post-index: "$index", layout: "row", layout-sm: "column", flex: true, id: "post-{{post.id}}"}


### PR DESCRIPTION
feat: main

Implements https://github.com/chutterbox/chutter/issues/28

You can now use `.primary-content` and `.secondary-content` to apply proper background. Primary content is white background and lighter grey on dark theme. Secondary content is greyish background and dark grey on dark theme (primary used in sidebars).
